### PR TITLE
Add workflow to run testkube tests from the pipeline

### DIFF
--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -97,7 +97,7 @@ jobs:
           echo "Execution Results = $(cat results.txt | grep "Execution ID" | head -n1)"
           echo "Execution ID = ${executionId}"
           kubectl testkube get tse ${executionId} -o json > results.json
-          cat results.json
+          ls -l *.json
           result=$(jq .status results.json | jq -r)
           echo "result=${result}"
           echo "result=${result}" >> $GITHUB_OUTPUT

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -11,9 +11,6 @@ on:
         description: "Name of Testsuite to run"
         required: true
         type: string
-      microservice:
-        description: "Name of the GitHub repository to update and run Testkube for"
-        required: true
       namespace:
         description: "Namespace of request objects to include"
         required: true
@@ -35,9 +32,6 @@ on:
   workflow_call:
     inputs:
       test-suite:        # Name of Testsuite to run
-        required: true
-        type: string
-      microservice:     # Name of the GitHub repository to update and run Testkube for
         required: true
         type: string
       namespace:        # Namespace of request objects to include

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -97,7 +97,7 @@ jobs:
           echo "Execution Results = $(cat results.txt | grep "Execution ID" | head -n1)"
           echo "Execution ID = ${executionId}"
           kubectl testkube get tse ${executionId} -o json > results.json
-          ls -l *.json
+          cat results.json
           result=$(jq .status results.json | jq -r)
           echo "result=${result}"
           echo "result=${result}" >> $GITHUB_OUTPUT

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -94,8 +94,10 @@ jobs:
         id: results
         run: | 
           executionId=$(cat results.txt | grep "Execution ID" | head -n1 | awk '{print $4}' | sed -e 's/\x1b\[[0-9;]*m//g')
+          echo "Execution Results = $(cat results.txt | grep "Execution ID" | head -n1)"
           echo "Execution ID = ${executionId}"
           kubectl testkube get tse ${executionId} -o json > results.json
+          ls -l *.json
           result=$(jq .status results.json | jq -r)
           echo "result=${result}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -1,0 +1,114 @@
+# CI workflow for running testkube test suites 
+name: Run Testkube test suite for MS
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Name of Testsuite to run"
+        required: true
+        type: string
+      microservice:
+        description: "Name of the GitHub repository to update and run Testkube for"
+        required: true
+      namespace:
+        description: "Namespace of request objects to include"
+        required: true
+      cluster:
+        description: "Cluster name to run testkube under"
+        type: choice
+        options:
+        - quartex-production
+        - quartex-dev-01
+        - quartex-development
+      aws-region:
+        description: "Set Region to find the cluster in"
+        type: choice
+        options:
+        - us-east-1
+      aws-role-arn:
+        type: string
+
+  workflow_call:
+    inputs:
+      test-suite:        # Name of Testsuite to run
+        required: true
+        type: string
+      microservice:     # Name of the GitHub repository to update and run Testkube for
+        required: true
+        type: string
+      namespace:        # Namespace of request objects to include
+        required: true
+        type: string
+      cluster:     # Cluster name to run testkube under
+        type: string
+        default: quartex-production
+      aws-region:           # Set Region to find the cluster in
+        type: string
+        default: us-east-1
+      aws-role-arn:
+        type: string
+    outputs:
+      result:
+        value: ${{ jobs.testkube.outputs.result }}
+    
+
+jobs:
+  testkube:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.results.outputs.result }}
+    steps:
+      # Checks-out repository
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials ${{ inputs.aws-region }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          role-duration-seconds: 900
+          aws-region: ${{ inputs.aws-region }}
+
+      # Install kubectl and testkube clis
+      - name: Install dependancies
+        run: |
+          curl -LO https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.17/2023-05-11/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          mv ./kubectl /usr/local/bin/kubectl
+
+          curl -LO https://github.com/kubeshop/testkube/releases/download/v1.13.3/testkube_1.13.3_Linux_x86_64.tar.gz
+          ls -l testkube_1.13.3_Linux_x86_64.tar.gz
+          gunzip testkube_1.13.3_Linux_x86_64.tar.gz
+          tar -xvf testkube_1.13.3_Linux_x86_64.tar
+          mv  kubectl-testkube /usr/local/bin/kubectl-testkube
+
+      - name: Configure EKS Cluster access
+        run: aws eks update-kubeconfig --name ${{ inputs.cluster }} --region ${{ inputs.aws-region }}     
+
+      - name: Apply manifests
+        working-directory: testkube/manifests
+        run: kubectl apply -f . -n ${{ inputs.namespace }}
+
+      - name: Run Test Suite
+        run: kubectl testkube run testsuite ${{ inputs.test-suite }} -n testkube -v NAMESPACE=${{ inputs.namespace }} --watch | tee results.txt
+
+      - name: Get test status
+        id: results
+        run: | 
+          executionId=$(cat results.txt | grep "Execution ID" | head -n1 | awk '{print $4}' | sed -e 's/\x1b\[[0-9;]*m//g')
+          echo "Execution ID = ${executionId}"
+          kubectl testkube get tse ${executionId} -o json > results.json
+          result=$(jq .status results.json | jq -r)
+          echo "result=${result}" >> $GITHUB_OUTPUT
+
+      - name: Appraise and report result
+        if: ${{steps.results.output.result == 'passed'}}
+        run: echo "Tests Result = ${steps.results.output.result}"
+
+      - name: Appraise and report result
+        if: ${{steps.results.output.result == 'failed'}}
+        run: echo "Tests Result = ${steps.results.output.result}" && exit 1

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Apply manifests
         working-directory: testkube/manifests
-        run: kubectl apply -f . -n ${{ inputs.namespace }}
+        run: kubectl apply -f .
 
       - name: Run Test Suite
         run: kubectl testkube run testsuite ${{ inputs.test-suite }} -n testkube -v NAMESPACE=${{ inputs.namespace }} --watch | tee results.txt

--- a/.github/workflows/testkube.yml
+++ b/.github/workflows/testkube.yml
@@ -99,6 +99,7 @@ jobs:
           kubectl testkube get tse ${executionId} -o json > results.json
           ls -l *.json
           result=$(jq .status results.json | jq -r)
+          echo "result=${result}"
           echo "result=${result}" >> $GITHUB_OUTPUT
 
       - name: Appraise and report result


### PR DESCRIPTION
# Overview

Migrate the testkube workflow, and bring it up to current standards

- Naming conventions for inputs
- AWS role/region inputs

Modify the workflow to expect the tests & definitions to live inside the current repo (not a different one), and auto-apply all manifest files.

# Version updates

MINOR change, as we are adding a new workflow, but there are no breaking changes to anything else.

# Workflow testing

There is still work to be done - as the workflow is not correctly parsing the `results.json`, or the json isn't valid, but this behaviour is in-line with the migrated workflow (see comparison). This work should probably happen as a PATCH update in future.

Work performed: [successful run](https://github.com/amdigital-co-uk/qtms-bookmarks/actions/runs/5691973995/job/15428231302)

Comparison: [successful run](https://github.com/amdigital-co-uk/qtms-bookmarks/actions/runs/5681353183/job/15397465989) from before the workflow was moved into the workflows repo.