### PR TITLE
Remove obsolete secret

### DIFF
--- a/.github/workflows/terraform-component-plan.yml
+++ b/.github/workflows/terraform-component-plan.yml
@@ -38,9 +38,6 @@ on:
       aws-role-arn:
         required: true
         type: string
-    secrets:
-      AWS_ROLE_ARN:
-        required: true
 
 jobs:
   tf-plan:


### PR DESCRIPTION
# Overview

Remove the secret definition for the (unused) secret.

# Version updates

Strictly this should probably be MAJOR, however marking as PATCH to avoid creating a v2. It is effectively a bugfix, and the sigle existing call site is known, so impact can be managed.

# Workflow testing

N/A
