### PR TITLE
Implement Terraform delete via label & add Checkov security checks

### DIFF
--- a/.github/workflows/terraform-component-plan.yml
+++ b/.github/workflows/terraform-component-plan.yml
@@ -38,6 +38,14 @@ on:
       aws-role-arn:
         required: true
         type: string
+      checkov-enabled:
+        type: boolean
+        default: false
+        required: false
+      checkov-skip-checks:
+        type: string
+        default: ""
+        required: false
 
 jobs:
   tf-plan:
@@ -46,6 +54,17 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+
+      - name: Run Checkov action
+        if: ${{ inputs.checkov-enabled }}
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: 'components/${{ inputs.component }}'
+          var_file: 'envs/prod.tfvars'
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+          skip_check: ${{ inputs.checkov-skip-checks }}
 
       - name: Set workspace based on branch
         env:
@@ -128,6 +147,7 @@ jobs:
           fi
 
       - name: Terraform Plan
+        if: '!contains(github.event.pull_request.labels.*.name, "destroy")'
         id: plan
         working-directory: components/${{ inputs.component }}
         env:
@@ -135,7 +155,17 @@ jobs:
         run: |
           terraform plan -no-color -var-file=envs/$TF_WORKSPACE.tfvars -out "${{ inputs.plan-id }}.tfplan" | tee ${{ github.workspace }}/plan.out
           aws s3 cp "${{ inputs.plan-id }}.tfplan" "s3://${{ inputs.s3-bucket }}${{ inputs.s3-bucket-prefix }}/${{ inputs.component }}/$TF_WORKSPACE/${{ inputs.plan-id }}.tfplan"
-          
+
+      - name: Terraform Destroy
+        if: contains(github.event.pull_request.labels.*.name, 'destroy')
+        id: destroy
+        working-directory: components/${{ inputs.component }}
+        env:
+          TF_WORKSPACE: ${{ env.WORKSPACE }}
+        run: |
+          terraform plan -no-color -var-file=envs/$TF_WORKSPACE.tfvars -out "${{ inputs.plan-id }}.tfplan" -destroy | tee ${{ github.workspace }}/plan.out
+          aws s3 cp "${{ inputs.plan-id }}.tfplan" "s3://${{ inputs.s3-bucket }}${{ inputs.s3-bucket-prefix }}/${{ inputs.component }}/$TF_WORKSPACE/${{ inputs.plan-id }}.tfplan"
+      
       - name: Format plan
         id: format-plan
         run: |

--- a/.github/workflows/terraform-component-plan.yml
+++ b/.github/workflows/terraform-component-plan.yml
@@ -187,13 +187,15 @@ jobs:
 
       - name: Post plan as a comment
         uses: actions/github-script@v6
+        env:
+          HEADER: ${{ contains(github.event.pull_request.labels.*.name, 'destroy') && 'Destroy' || 'Plan' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const plan = fs.readFileSync('plan.out');
             const summary = fs.readFileSync('summary.out');
-            const output = `### Infrastructure plan: ${{ inputs.COMPONENT }}
+            const output = `### ${{ env.HEADER }} Infrastructure: ${{ inputs.COMPONENT }}
             #### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`

--- a/.github/workflows/terraform-component-plan.yml
+++ b/.github/workflows/terraform-component-plan.yml
@@ -147,7 +147,7 @@ jobs:
           fi
 
       - name: Terraform Plan
-        if: '!contains(github.event.pull_request.labels.*.name, "destroy")'
+        if: "!contains(github.event.pull_request.labels.*.name, 'destroy')"
         id: plan
         working-directory: components/${{ inputs.component }}
         env:

--- a/.github/workflows/terraform-component-plan.yml
+++ b/.github/workflows/terraform-component-plan.yml
@@ -55,17 +55,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Run Checkov action
-        if: ${{ inputs.checkov-enabled }}
-        id: checkov
-        uses: bridgecrewio/checkov-action@master
-        with:
-          directory: 'components/${{ inputs.component }}'
-          var_file: 'envs/prod.tfvars'
-          output_format: cli,sarif
-          output_file_path: console,results.sarif
-          skip_check: ${{ inputs.checkov-skip-checks }}
-
       - name: Set workspace based on branch
         env:
           REF: ${{ github.ref_name }}
@@ -145,6 +134,17 @@ jobs:
             echo Getting secret ${{ inputs.aws-secret-name }}
             aws secretsmanager get-secret-value --secret-id "${{ inputs.aws-secret-name }}" --query SecretString --output text > secrets.auto.tfvars
           fi
+
+      - name: Run Checkov security checks
+        if: ${{ inputs.checkov-enabled }}
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: 'components/${{ inputs.component }}'
+          var_file: 'envs/${{ env.WORKSPACE }}.tfvars'
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+          skip_check: ${{ inputs.checkov-skip-checks }}
 
       - name: Terraform Plan
         if: "!contains(github.event.pull_request.labels.*.name, 'destroy')"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is an experimental replacement for [quartex-workflows](https://github.com/a
 Note that our secrets are defined at organisation level. So whilst shouldn't need defining within the repository, they do need to be explicitly passed in to the called workflow.
 
 - [Shared .NET workflows](./DOTNET.md)
+- [Shared Terraform workflows](./TERRAFORM.md)
 - [Generic Docker build and push to ECR](./OTHER.md#build-a-docker-application-and-push-to-ecr)
 - [Publish an AWS Lambda using Serverless](./OTHER.md#deploy-a-nodejs-lambda-function-using-docker--serverless)
 - [Run NodeJS unit tests](./OTHER.md#run-unit-tests-for-a-nodejs-application)

--- a/TERRAFORM.md
+++ b/TERRAFORM.md
@@ -22,7 +22,7 @@ Finally, it is also possible to configure Checkov to run on the terraform files.
       component: COMPONENT
       plan-id: ${{ github.event.number }}
       aws-role-arn: ${{ vars.ROLE_ARN }}
-      terraform-version: 1.3.7              # Optional, defaults to 1.15
+      terraform-version: 1.3.7              # Optional, defaults to 1.1.5
       use-aws-secret: true                  # Optional, defaults to false. If set to true, also populate the below
       aws-secret-name: secret/key           # Optional, the name of the secret in AWS Secrets
       append-workspace-to-secret: false     # Optional, defaults to false. If true, workspace name gets appended to the secret name
@@ -50,7 +50,7 @@ jobs:
       component: COMPONENT
       plan-id: ${{ github.event.number }}
       aws-role-arn: ${{ vars.ROLE_ARN }}
-      terraform-version: 1.3.7              # Optional, defaults to 1.15
+      terraform-version: 1.3.7              # Optional, defaults to 1.1.5
       s3-bucket: my-s3-bucket               # Optional, defaults to our standardd bucket. S3 bucket to store the plan in
       s3-key: /plans                        # Optional, defaults to /plans. S3 path to store for the plan in
 

--- a/TERRAFORM.md
+++ b/TERRAFORM.md
@@ -1,0 +1,57 @@
+# Shared AWS Terraform workflows
+
+## Terraform Plan
+
+This workflow is usually run in the context of a Pull Request, and assumes that the terraform repository is structured as follows:
+
+- `components/{component-name}/*.tf` - the terraform files for the component
+- `components/{component-name}/{env}.tfvars` - the terraform variables for a given environment
+
+It will use the terraform CLI to plan the changes that would be made to the infrastructure if the PR were to be merged. It will then upload the plan to S3 and comment on the PR with a summary of the plan.
+
+It will optionally load in secrets from AWS Secrets manager as an additional source of terraform variables.
+
+Finally, it is also possible to configure Checkov to run on the terraform files. The workflow will fail if any Checkov checks fail, and it is also possible to skip certain checks.
+
+
+```yml
+  plan:
+    name: "Plan COMPONENT Updates"
+    uses: amdigital-co-uk/workflows/.github/workflows/terraform-component-plan.yml@v1
+    with:
+      component: COMPONENT
+      plan-id: ${{ github.event.number }}
+      aws-role-arn: ${{ vars.ROLE_ARN }}
+      terraform-version: 1.3.7              # Optional, defaults to 1.15
+      use-aws-secret: true                  # Optional, defaults to false. If set to true, also populate the below
+      aws-secret-name: secret/key           # Optional, the name of the secret in AWS Secrets
+      append-workspace-to-secret: false     # Optional, defaults to false. If true, workspace name gets appended to the secret name
+      s3-bucket: my-s3-bucket               # Optional, defaults to our standardd bucket. S3 bucket to store the plan in
+      s3-key: /plans                        # Optional, defaults to /plans. S3 path to store for the plan in
+      checkov-enabled: true                 # Optional, defaults to false. Whether to run Checkov on the terraform files
+      checkov-skip-checks: "CKV_AWS_247"    # Optional, defaults to empty. A comma-separated list of check IDs to skip
+```
+
+### Terraform destroy
+
+If adding the `destroy` label to a Pull Request, the workflow will instead create a plan to destroy the infrastructure instead of updating it. **Use with caution**.
+
+## Terraform Apply
+
+Usually run in the context of a _merged_ Pull Request. It will use the terraform CLI to apply the changes that were planned in the PR. It will then upload the plan to S3 and comment on the PR with a summary of the plan. Finally, it will post any Terraform outputs as a comment on the PR.
+
+```yml
+jobs:
+  apply:
+    if: ${{ github.event.pull_request.merged == true }}
+    name: "Apply elasticsearch Changes"
+    uses: amdigital-co-uk/workflows/.github/workflows/terraform-component-apply.yml@v1
+    with:
+      component: COMPONENT
+      plan-id: ${{ github.event.number }}
+      aws-role-arn: ${{ vars.ROLE_ARN }}
+      terraform-version: 1.3.7              # Optional, defaults to 1.15
+      s3-bucket: my-s3-bucket               # Optional, defaults to our standardd bucket. S3 bucket to store the plan in
+      s3-key: /plans                        # Optional, defaults to /plans. S3 path to store for the plan in
+
+```


### PR DESCRIPTION
# Overview

## Checkov security checking

Use the `bridgecrewio/checkov-action@master` shared action to implement checkov security checking. Controlled by two new inputs:

- `checkov-enabled` (defaults to `false`): Whether or not the security checks should be run
- `checkov-skip-checks` (defaults to empty string): what security checks should be skipped

## Terraform destroy functionality

When the `destroy` label is added to a PR, the terraform plan workflow will make a plan to destroy, rather than update the infrastructure. Modelled off [similar functionality](https://github.com/amdigital-co-uk/qtif-k8s-clusters/blob/main/.github/workflows/shared-plan.yml#L111) in `qtif-kubernetes`.

# Version updates

This is a MINOR update. New functionality has been added in a backwards-compatible fashion, by exposing the new workflow inputs and using a label.

# Workflow testing

See changed files, comments and workflows associated with this PR: [Elastic Search - Update workflows](https://github.com/amdigital-co-uk/qtif-elasticsearch/pull/24).
