### PR TITLE
Fix versioning script

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -28,7 +28,7 @@ jobs:
           PATCH: ${{ contains(github.event.pull_request.labels.*.name, 'patch') }}
         run: |
           # Get the latest tag and remove the leading 'v'
-          version=$(git tag --list v*.*.* | sort | tail -n1 | cut -dv -f2-)
+          version=$(git tag --list v*.*.* | sort -V | tail -n1 | cut -dv -f2-)
           echo version=$version
 
           # Set the version output


### PR DESCRIPTION
# Overview

The `sort` command in the `Add Git tags` workflow failed when any of the SEMVER components went above 9.

I.e. v1.9.x sorts **higher** than v1.10.x, which leads to subsequent version bumps being mis-applied.

The `sort` command has a `-V` flag which sorts according to SEMVER spec, so this appears to fix the issue.

Summary of changes. Describe the problem being solved and how you approached the solution.

# Version updates

PATCH version update to re-apply the version updates I was attempting to apply last time! This will hopefully result in the following tags being created:

- `v1`: updated to point to latest commit in main
- `v1.10`: updated to point to latest commit in main
- `v1.10.1`: new tag, pointing to lates commit in main

# Workflow testing

N/A - this isn't a change to any workflows.
