### PR TITLE
Add .NET version as a parameter to Serverless

### DIFF
--- a/.github/workflows/serverless-dotnet.yml
+++ b/.github/workflows/serverless-dotnet.yml
@@ -60,7 +60,7 @@ jobs:
           include-prerelease: true
       
       - name: Publish .NET application
-        run: dotnet publish $PROJECT/$PROJECT.csproj --output _publish --configuration "Release" --framework "net6.0" /p:GenerateRuntimeConfigurationFiles=true --runtime linux-x64 --self-contained false
+        run: dotnet publish $PROJECT/$PROJECT.csproj --output _publish --configuration "Release" /p:GenerateRuntimeConfigurationFiles=true --runtime linux-x64 --self-contained false
       
       - name: Create Package
         working-directory: _publish

--- a/.github/workflows/serverless-dotnet.yml
+++ b/.github/workflows/serverless-dotnet.yml
@@ -12,6 +12,10 @@ on:
       stage:       # Serverless Stage
         required: true
         type: string
+      dotnet-version:
+        required: false
+        type: string
+        default: '6.0.x'
       node-version:
         type: string
         default: '14.x'
@@ -52,7 +56,7 @@ jobs:
       # Publish .NET project and create Zip
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: ${{ inputs.dotnet-version }}
           include-prerelease: true
       
       - name: Publish .NET application


### PR DESCRIPTION
# Overview

Allows building .NET lambda functions using other versions

# Version updates

MINOR: Adding a new parameter, but it is not required and defaults to the originally hardcoded value. This will be backwards compatible.

# Workflow testing

Successfully deployed [Support Toolkit lambda](https://github.com/amdigital-co-uk/qtfn-stk-framework/actions/runs/8295778041/job/22703679297).
