### PR TITLE
Add input to allow argo-rollouts-version to be specified

### DIFF
--- a/.github/workflows/promote-rollback.yml
+++ b/.github/workflows/promote-rollback.yml
@@ -33,7 +33,7 @@ on:
       argo-rollouts-version:
         type: string
         description: "Version of Argo Rollouts to use"
-        default: "latest/download"
+        default: "v1.5.1"
 
 jobs:
   promote_or_rollback:
@@ -52,7 +52,7 @@ jobs:
           chmod +x kubectl
           mv ./kubectl /usr/local/bin/kubectl
 
-          curl -LO https://github.com/argoproj/argo-rollouts/releases/${{inputs.argo-rollouts-version}}/kubectl-argo-rollouts-linux-amd64
+          curl -LO https://github.com/argoproj/argo-rollouts/releases/download/${{inputs.argo-rollouts-version}}/kubectl-argo-rollouts-linux-amd64
           chmod +x ./kubectl-argo-rollouts-linux-amd64
           mv ./kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
 

--- a/.github/workflows/promote-rollback.yml
+++ b/.github/workflows/promote-rollback.yml
@@ -30,6 +30,10 @@ on:
         type: boolean
         description: "Flag that determines if we're promoting or rolling back, true = promote, false = rollback"
         default: false
+      argo-rollouts-version:
+        type: string
+        description: "Version of Argo Rollouts to use"
+        default: "latest/download"
 
 jobs:
   promote_or_rollback:
@@ -48,7 +52,7 @@ jobs:
           chmod +x kubectl
           mv ./kubectl /usr/local/bin/kubectl
 
-          curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+          curl -LO https://github.com/argoproj/argo-rollouts/releases/${{inputs.argo-rollouts-version}}/kubectl-argo-rollouts-linux-amd64
           chmod +x ./kubectl-argo-rollouts-linux-amd64
           mv ./kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
 


### PR DESCRIPTION
# Overview

Update the promote-rollback workflow to allow for the version of argo rollouts to be specified

# Version updates

PATCH

# Workflow testing

https://github.com/amdigital-co-uk/qtms-public-api/actions/runs/9097958884
