### PR TITLE
Add config file copy parameters to dotnet-test workflows

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -30,6 +30,7 @@ on:
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
+        required: false
 
 jobs:
   dotnet-test:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -14,6 +14,15 @@ on:
         required: false
         type: string
         default: null
+      config-file-s3-root:
+        required: false
+        type: string
+      config-file:
+        required: false
+        type: string
+      copy-config-file-to-projects:
+        required: false
+        type: string
     secrets:
       PKG_TOKEN:
         required: true
@@ -26,6 +35,27 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      # Copy config files from S3
+      - name: Copy config file from s3 
+        if: ${{ inputs.config-file != ''}}
+        env:
+          CONFIG_FILE: ${{ inputs.config-file }}
+          CONFIG_FILE_S3_ROOT: ${{ inputs.config-file-s3-root }}
+        run: |
+          aws s3 cp $CONFIG_FILE_S3_ROOT/$CONFIG_FILE .
+
+      # Copy config files to projects
+      - name: Copy config file to projects
+        if: ${{ inputs.copy-config-file-to-projects != '' }}
+        env:
+          PROJECTS: ${{ inputs.copy-config-file-to-projects }}
+          CONFIG_FILE: ${{ inputs.config-file }}
+        run: |
+          for project in $PROJECTS
+          do
+            cp $CONFIG_FILE $project
+          done
 
       # Spins up services via Docker-compose
       - name: Start containers

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -14,12 +14,9 @@ on:
         required: false
         type: string
         default: null
-      region:
+      aws-region:
         type: string
         default: us-east-1
-      aws-role-arn:
-        required: true
-        type: string
       config-file-s3-root:
         required: false
         type: string
@@ -31,6 +28,8 @@ on:
         type: string
     secrets:
       PKG_TOKEN:
+        required: true
+      AWS_ROLE_ARN:
         required: true
 
 jobs:
@@ -47,9 +46,9 @@ jobs:
         if: ${{ inputs.config-file != ''}}
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ inputs.aws-role-arn }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-duration-seconds: 900
-          aws-region: ${{ inputs.region }}
+          aws-region: ${{ inputs.aws-region }}
 
       - name: Copy config file from s3 
         if: ${{ inputs.config-file != ''}}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -30,7 +30,6 @@ on:
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
-        required: true
 
 jobs:
   dotnet-test:
@@ -51,7 +50,7 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
 
       - name: Copy config file from s3 
-        if: ${{ inputs.config-file != ''}}
+        if: ${{ inputs.config-file != '' && inputs.config-file-s3-root != ''}}
         env:
           CONFIG_FILE: ${{ inputs.config-file }}
           CONFIG_FILE_S3_ROOT: ${{ inputs.config-file-s3-root }}
@@ -60,7 +59,7 @@ jobs:
 
       # Copy config files to projects
       - name: Copy config file to projects
-        if: ${{ inputs.copy-config-file-to-projects != '' }}
+        if: ${{ inputs.config-file && inputs.copy-config-file-to-projects != '' }}
         env:
           PROJECTS: ${{ inputs.copy-config-file-to-projects }}
           CONFIG_FILE: ${{ inputs.config-file }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -14,6 +14,12 @@ on:
         required: false
         type: string
         default: null
+      region:
+        type: string
+        default: us-east-1
+      aws-role-arn:
+        required: true
+        type: string
       config-file-s3-root:
         required: false
         type: string
@@ -37,6 +43,14 @@ jobs:
         uses: actions/checkout@v3
 
       # Copy config files from S3
+      - name: Configure AWS credentials
+        if: ${{ inputs.config-file != ''}}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          role-duration-seconds: 900
+          aws-region: ${{ inputs.region }}
+
       - name: Copy config file from s3 
         if: ${{ inputs.config-file != ''}}
         env:


### PR DESCRIPTION
# Overview

Allows for microservices to be tested when config files are required

# Version updates

MINOR: Adding new parameters that aren't required so this workflow is still backwards compatible.

# Workflow testing

Successfully running on [qtms-pages](https://github.com/amdigital-co-uk/qtms-pages/actions/runs/9747640708/job/26900814085).
