### PR TITLE
Add config file copy parameters to dotnet-test workflows

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -30,7 +30,10 @@ on:
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
+<<<<<<< HEAD
         required: false
+=======
+>>>>>>> ae70af0 (Adjust required inputs and checks)
 
 jobs:
   dotnet-test:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -31,9 +31,13 @@ on:
         required: true
       AWS_ROLE_ARN:
 <<<<<<< HEAD
+<<<<<<< HEAD
         required: false
 =======
 >>>>>>> ae70af0 (Adjust required inputs and checks)
+=======
+        required: false
+>>>>>>> dcdae33 (Make AWS_ROLE_ARN not required)
 
 jobs:
   dotnet-test:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Copy config files from S3
+      # Configure AWS credentials
       - name: Configure AWS credentials
         if: ${{ inputs.config-file != ''}}
         uses: aws-actions/configure-aws-credentials@v2
@@ -50,6 +50,7 @@ jobs:
           role-duration-seconds: 900
           aws-region: ${{ inputs.aws-region }}
 
+      # Copy config files from S3
       - name: Copy config file from s3 
         if: ${{ inputs.config-file != '' && inputs.config-file-s3-root != ''}}
         env:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -30,14 +30,7 @@ on:
       PKG_TOKEN:
         required: true
       AWS_ROLE_ARN:
-<<<<<<< HEAD
-<<<<<<< HEAD
         required: false
-=======
->>>>>>> ae70af0 (Adjust required inputs and checks)
-=======
-        required: false
->>>>>>> dcdae33 (Make AWS_ROLE_ARN not required)
 
 jobs:
   dotnet-test:


### PR DESCRIPTION
# Overview

Allows for microservices to be tested when config files are required

# Version updates

MINOR: Adding new parameters that aren't required so this workflow is still backwards compatible.

# Workflow testing

Successfully running on [qtms-pages](https://github.com/amdigital-co-uk/qtms-pages/actions/runs/9747640708/job/26900814085).
