### PR TITLE
Update get-config and deploy to support AWS Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ on:
       service-name:
         type: string
         required: true
+      aws-secrets-prefix:
+        type: string
+        required: true
 jobs:
   deploy:
     name: Helm
@@ -77,6 +80,7 @@ jobs:
           sed -i helm/values.yaml -e "s|<envClusterSuffix>|${{ inputs.cluster-suffix }}|g"
           sed -i helm/values.yaml -e "s|<envGlobalSuffix>|${{ inputs.global-suffix }}|g"
           sed -i helm/values.yaml -e "s|<esUrl>|${{ inputs.elastic-search-url }}|g"
+          sed -i helm/values.yaml -e "s|<aws_secets>|${{ inputs.aws-secrets-prefix }}|g"
           cat helm/values.yaml
 
       - name: Deploy helm release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,6 @@ on:
         required: true
       aws-secrets-prefix:
         type: string
-        required: true
 jobs:
   deploy:
     name: Helm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           sed -i helm/values.yaml -e "s|<envClusterSuffix>|${{ inputs.cluster-suffix }}|g"
           sed -i helm/values.yaml -e "s|<envGlobalSuffix>|${{ inputs.global-suffix }}|g"
           sed -i helm/values.yaml -e "s|<esUrl>|${{ inputs.elastic-search-url }}|g"
-          sed -i helm/values.yaml -e "s|<aws_secets>|${{ inputs.aws-secrets-prefix }}|g"
+          sed -i helm/values.yaml -e "s|<awsSecretsPrefix>|${{ inputs.aws-secrets-prefix }}|g"
           cat helm/values.yaml
 
       - name: Deploy helm release

--- a/.github/workflows/get-config.yml
+++ b/.github/workflows/get-config.yml
@@ -18,8 +18,8 @@ on:
         value: ${{ jobs.get-config.outputs.esUrl }}
       namespace:
         value: ${{ jobs.get-config.outputs.namespace }}
-      aws_secrets:
-        value: ${{ jobs.get-config.outputs.aws_secrets }}
+      awsSecretsPrefix:
+        value: ${{ jobs.get-config.outputs.awsSecretsPrefix }}
 
 jobs:
   get-config:
@@ -40,14 +40,14 @@ jobs:
           clusterSuffix="-live.live.svc.cluster.local"
           globalSuffix=".quartexcollections.com"
           esUrl="http://elasticsearch-internal.quartex.uk"
-          aws_secrets="quartex/secrets/live"
+          awsSecretsPrefix="quartex/secrets/live"
 
           if [[ $envLower == qa* ]] 
           then
             cluster="quartex-development"
             clusterSuffix=""
             globalSuffix=".${envLower}.quartex.uk"
-            aws_secrets="quartex/secrets/qa"
+            awsSecretsPrefix="quartex/secrets/qa"
           fi
 
           if [[ $envLower == dev* ]] 
@@ -56,7 +56,7 @@ jobs:
             clusterSuffix=""
             globalSuffix=".${envLower}.quartex.uk"
             esUrl="http://elasticsearch.${envLower}:9200"
-            aws_secrets="quartex/development/${envLower}"
+            awsSecretsPrefix="quartex/development/${envLower}"
           fi
 
           echo "cluster=$cluster" >> $GITHUB_OUTPUT
@@ -64,4 +64,4 @@ jobs:
           echo "global-suffix=$globalSuffix" >> $GITHUB_OUTPUT
           echo "es-url=$esUrl" >> $GITHUB_OUTPUT
           echo "namespace=$envLower" >> $GITHUB_OUTPUT
-          echo "aws_secrets=$aws_secrets" >> $GITHUB_OUTPUT
+          echo "aws-secrets-prefix=$awsSecretsPrefix" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-config.yml
+++ b/.github/workflows/get-config.yml
@@ -18,6 +18,8 @@ on:
         value: ${{ jobs.get-config.outputs.esUrl }}
       namespace:
         value: ${{ jobs.get-config.outputs.namespace }}
+      aws_secrets:
+        value: ${{ jobs.get-config.outputs.aws_secrets }}
 
 jobs:
   get-config:
@@ -38,12 +40,14 @@ jobs:
           clusterSuffix="-live.live.svc.cluster.local"
           globalSuffix=".quartexcollections.com"
           esUrl="http://elasticsearch-internal.quartex.uk"
+          aws_secrets="quartex/secrets/live"
 
           if [[ $envLower == qa* ]] 
           then
             cluster="quartex-development"
             clusterSuffix=""
             globalSuffix=".${envLower}.quartex.uk"
+            aws_secrets="quartex/secrets/qa"
           fi
 
           if [[ $envLower == dev* ]] 
@@ -52,6 +56,7 @@ jobs:
             clusterSuffix=""
             globalSuffix=".${envLower}.quartex.uk"
             esUrl="http://elasticsearch.${envLower}:9200"
+            aws_secrets="quartex/development/${envLower}"
           fi
 
           echo "cluster=$cluster" >> $GITHUB_OUTPUT
@@ -59,3 +64,4 @@ jobs:
           echo "global-suffix=$globalSuffix" >> $GITHUB_OUTPUT
           echo "es-url=$esUrl" >> $GITHUB_OUTPUT
           echo "namespace=$envLower" >> $GITHUB_OUTPUT
+          echo "aws_secrets=$aws_secrets" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-config.yml
+++ b/.github/workflows/get-config.yml
@@ -30,6 +30,7 @@ jobs:
         globalSuffix: ${{ steps.get-config.outputs.global-suffix }}
         esUrl: ${{ steps.get-config.outputs.es-url }}
         namespace: ${{ steps.get-config.outputs.namespace }}
+        awsSecretsPrefix: ${{ steps.get-config.outputs.aws-secrets-prefix }}
     steps:
       - name: Set Config Outputs
         id: get-config 


### PR DESCRIPTION
# Overview

- get-config.yml generates a new output variable of the AWS secrets prefix for each environment type (Dev, QA and Live)
- deploy.yml will now support an input of aws-secrets-prefix which can be used within helm values.yaml files

# Version updates

MINOR - Adds new functionality but will not break existing changes.

# Workflow testing

https://github.com/amdigital-co-uk/qtms-publish-dispatcher/actions/runs/9988847770
