### PR TITLE
Use valid version string

### DIFF
--- a/.github/workflows/serverless-dotnet.yml
+++ b/.github/workflows/serverless-dotnet.yml
@@ -18,7 +18,7 @@ on:
         default: '6.0.x'
       node-version:
         type: string
-        default: 'lts'
+        default: '20'
       project:
         required: true
         type: string


### PR DESCRIPTION
# Overview

The string `lts` does not work as the `node-version` input to `actions/setup-node`, so instead this PR hardcodes the current major LTS version.

# Version updates

Marking this as a PATCH version update as it bug, and the previous MINOR update is broken anyway.
