### PR TITLE
Pin specific version of serverless

### DIFF
--- a/.github/workflows/serverless-dotnet.yml
+++ b/.github/workflows/serverless-dotnet.yml
@@ -106,7 +106,7 @@ jobs:
       
       # Install serverless node package
       - name: Install serverless
-        run: npm i -g serverless
+        run: npm i -g serverless@3
 
       # Package up the application
       - name: Package 

--- a/.github/workflows/serverless-nodejs.yml
+++ b/.github/workflows/serverless-nodejs.yml
@@ -100,7 +100,7 @@ jobs:
       
       # Install serverless node package
       - name: Install serverless
-        run: npm i -g serverless
+        run: npm i -g serverless@3
 
       # Package up the application
       - name: Package 


### PR DESCRIPTION
# Overview

Explicitly pin the latest version 3 release available. Version 4 moves to a different license model for which we don't have an API key.

# Version updates

This is a PATCH change, as there are no externally visible changes, just an internal change to fix a bug.

# Workflow testing

Successful deploy of the [qtfn-config lambda](https://github.com/amdigital-co-uk/qtfn-config/actions/runs/10147440157/workflow).
